### PR TITLE
Add input fontsize rem -> px

### DIFF
--- a/src/components/SearchBar/style.ts
+++ b/src/components/SearchBar/style.ts
@@ -11,7 +11,8 @@ export const SearchInput = styled.input`
   width: 100%;
   padding: 1rem;
   border: none;
-  font-size: 1rem;
+  /* absolute px - for Remove iOS zoom in */
+  font-size: 16px;
   border-radius: 0.625rem;
   border: 0.0625rem solid ${({ theme }) => theme.color.grey[100]};
 

--- a/src/components/SearchBar/style.ts
+++ b/src/components/SearchBar/style.ts
@@ -11,10 +11,13 @@ export const SearchInput = styled.input`
   width: 100%;
   padding: 1rem;
   border: none;
-  /* absolute px - for Remove iOS zoom in */
-  font-size: 16px;
+  font-size: 1rem;
   border-radius: 0.625rem;
   border: 0.0625rem solid ${({ theme }) => theme.color.grey[100]};
+
+  @media (max-width: 600px) {
+    font-size: 16px;
+  }
 
   &::placeholder {
     ${({ theme }) => theme.typo.body1};

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -58,10 +58,6 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
-  input {
-    font-size: 16px !important;
-  }
-
   button {
     padding: 0;
     border: none;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -45,7 +45,6 @@ const GlobalStyle = createGlobalStyle`
     }
     @media (max-width: 400px) {
       font-size: 11px;
-
     }
     @media (max-width: 370px) {
       font-size: 10px;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -58,6 +58,10 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  input {
+    font-size: 16px !important;
+  }
+
   button {
     padding: 0;
     border: none;


### PR DESCRIPTION
## 개요 💡

> iOS input zoom in 대응

## 작업내용 ⌨️

- input fontsize가 16px 미만일 때, 발생하는 현상으로 input은 rem 단위가 아닌 px 값으로 font-size를 조정하였습니다

### before

https://github.com/GSM-Networking/GSM-Networking-client/assets/80103328/042003c7-2d26-485f-9ac3-5d2fe79f74d5

### after

https://github.com/GSM-Networking/GSM-Networking-client/assets/80103328/b113bf2d-aba6-4ba0-aeb9-36a99927908d